### PR TITLE
use world.getTopSolidOrLiquidBlock to find top block

### DIFF
--- a/src/main/java/primetoxinz/coralreef/GeneratorReef.java
+++ b/src/main/java/primetoxinz/coralreef/GeneratorReef.java
@@ -1,5 +1,6 @@
 package primetoxinz.coralreef;
 
+import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -67,10 +68,14 @@ public class GeneratorReef implements IWorldGenerator {
 
     public static BlockPos getTop(World world, int x, int z) {
         Chunk chunk = world.getChunkFromBlockCoords(new BlockPos(x, 0, z));
-        BlockPos.MutableBlockPos blockPos = new BlockPos.MutableBlockPos(x, chunk.getTopFilledSegment(), z);
+        BlockPos.MutableBlockPos blockPos = new BlockPos.MutableBlockPos(world.getTopSolidOrLiquidBlock(
+                new BlockPos(x, 0, z)));
+
         for (; blockPos.getY() >= 0; blockPos.setY(blockPos.getY() - 1)) {
             IBlockState state = chunk.getBlockState(blockPos);
-            if (state.getMaterial().isSolid() && !state.getBlock().isLeaves(state, world, blockPos) && !state.getBlock().isFoliage(world, blockPos)) {
+            if (state.getMaterial().blocksMovement()
+                    && state.getMaterial() != Material.LEAVES
+                    && !state.getBlock().isFoliage(world, blockPos)) {
                 break;
             }
         }


### PR DESCRIPTION
The use of chunk.getTopFilledSegment was incorrect; it sometimes returns
a height *below* the topmost block, which prevented spawning a reef
there. This was only found upon changing the code to make all topmost
blocks into reef, and discovering just how much of the world did not
convert. It was particularly bad around slopes and beaches.

Contrary to its name, getTopSolidOrLiquidBlock walks through all blocks
that don't block movement, plus leaves and foliage. We duplicate the
functionality in getTop on purpose, to allow spawning reefs under other
blocks in future (e.g. ice).